### PR TITLE
Fix handling for Facebook users without public email. Use Facebook ID as fallback

### DIFF
--- a/Fun/LoginViewController.swift
+++ b/Fun/LoginViewController.swift
@@ -16,15 +16,23 @@ class LoginViewController: UIViewController, FBLoginViewDelegate {
     }
     
     func loginViewFetchedUserInfo(loginView : FBLoginView!, user: FBGraphUser) {
-        NSLog("Facebook login successful")
-        var email = user.objectForKey("email") as String
+        NSLog("Facebook login successful");
 
         User.currentUser.facebookName = user.objectForKey("name") as? String
-        User.currentUser.facebookID = user.objectForKey("id") as NSString
+        User.currentUser.facebookID = user.objectForKey("id") as? String
         User.currentUser.getFacebookProfilePicture { _ in
             
         }
-        FunSession.sharedSession.signIn(email) {
+        
+        var loginEmail: String;
+        if let email = user.objectForKey("email") as? String {
+            loginEmail = email;
+        }
+        else {
+            loginEmail = "\(User.currentUser.facebookID!)@facebook.com"
+        }
+        
+        FunSession.sharedSession.signIn(loginEmail) {
             NSLog("API signin successful")
             dispatch_async(dispatch_get_main_queue()) {
                 self.performSegueWithIdentifier("loggedIn", sender: self)


### PR DESCRIPTION
Fixes crash when no public email is available. Uses [facebook id]@facebook.com as a default in this case.